### PR TITLE
Docker image + docs in the readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,14 @@ FROM golang:1.10-alpine
 ARG MOUTHFUL_VER
 ENV CGO_ENABLED=${CGO_ENABLED:-1} \
     GOOS=${GOOS:-linux} \
-    MOUTHFUL_VER=${MOUTHFUL_VER:-1.0.2}
+    MOUTHFUL_VER=${MOUTHFUL_VER:-master}
 RUN set -ex; \
     apk add --no-cache bash build-base curl git && \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     apk add --no-cache upx nodejs nodejs-npm && \
     go get -d github.com/vkuznecovas/mouthful && \
-    curl -sSL https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 -o /usr/bin/dep && \
-    chmod +x /usr/bin/dep
+    go get github.com/golang/dep
 WORKDIR /go/src/github.com/vkuznecovas/mouthful
 RUN git checkout $MOUTHFUL_VER && \
     ./build.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,25 @@
-FROM centos:latest
-ADD dist/ /
-CMD ["./mouthful"] 
+FROM golang:1.10-alpine
+ARG MOUTHFUL_VER
+ENV CGO_ENABLED=${CGO_ENABLED:-1} \
+    GOOS=${GOOS:-linux} \
+    MOUTHFUL_VER=${MOUTHFUL_VER:-1.0.2}
+RUN set -ex; \
+    apk add --no-cache bash build-base curl git && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    apk add --no-cache upx nodejs nodejs-npm && \
+    go get -d github.com/vkuznecovas/mouthful && \
+    curl -sSL https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 -o /usr/bin/dep && \
+    chmod +x /usr/bin/dep
+WORKDIR /go/src/github.com/vkuznecovas/mouthful
+RUN git checkout $MOUTHFUL_VER && \
+    ./build.sh && \
+    cd dist/ && \
+    upx --best mouthful
+
+FROM alpine:3.7
+COPY --from=0 /go/src/github.com/vkuznecovas/mouthful/dist/ /app/
+WORKDIR /app/
+VOLUME [ "/app/data" ]
+EXPOSE 8080
+CMD ["/app/mouthful"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex; \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     apk add --no-cache upx nodejs nodejs-npm && \
     go get -d github.com/vkuznecovas/mouthful && \
-    go get github.com/golang/dep
+    go get -u github.com/golang/dep/cmd/dep
 WORKDIR /go/src/github.com/vkuznecovas/mouthful
 RUN git checkout $MOUTHFUL_VER && \
     ./build.sh && \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ Mouthful is a lightweight commenting server written in GO and Preact. It's a sel
 
 There's a demo hosted at [mouthful.dizzy.zone](https://mouthful.dizzy.zone). Check it out!
 
+* [Features](#features)
+* [Get mouthful](#installation)
+    * [The easy way](#the-easy-way)
+    * [Build from source](#building-mouthful-yourself)
+    * [Run it on Docker](#mouthful-on-docker)
+* [Configure mouthful](#configuring-mouthful)
+    * [Moderation](#moderation)
+    * [Caching](#caching)
+    * [Rate limiting](#rate-limiting)
+    * [Styling](#styling)
+    * [Cross-origin resource sharing](#cross-origin resource sharing)
+    * [Data sources](#data-source)
+    * [Config file from Docker image](#config-file-from-docker)
+* [Contributing](#contributing)
+* [Wish list](#wish-list)
+* [Get in touch](#get-in-touch)
+* [Who uses mouthful](#who-uses-mouthful?)
+
 # Features
 
 * Multiple database support(sqlite, mysql, postgres, dynamodb)
@@ -19,12 +37,9 @@ There's a demo hosted at [mouthful.dizzy.zone](https://mouthful.dizzy.zone). Che
 * Migrations from existing commenting engines(isso)
 * Configuration - most of the features can be turned on or off, as well as customized to your preferences.
 
-
 # Installation
 
-
 ## The easy way
-
 
 ### Backend
 
@@ -64,12 +79,58 @@ To configure your mouthful instance to your hearts content, please refer to the 
 
 Once you've done with the configuration, just copy over the `/dist` contents to your server and run the `/dist/mouthful` binary. Take note that the mouthful binary will look for a config.json file its directory.
 
-## Installing dependencies
+### Installing dependencies
 
 1) To install Go, please refer to the GO documentation found [here](https://golang.org/doc/install#install)
 1) To install node and npm, please refer to the Node documentation found [here](https://nodejs.org/en/download/package-manager/)
 1) To install Dep, please refer to Dep documentation found [here](https://github.com/golang/dep#installation)
 1) Once you have all the tools installed, follow the [Installation guide](#installation)
+
+## Mouthful on Docker
+
+### Build the image
+
+1. Clone the project
+
+```sh
+git clone https://github.com/vkuznecovas/mouthful.git
+```
+
+2. Get in the project folder then build the image
+    
+```sh
+docker build -t mouthful .
+```
+
+The [`Dockerfile`](Dockerfile) is going to build on the master branch by default, you can specify a version
+
+```sh
+docker build --build-args "MOUTHFUL_VER=1.0.3" -t mouthful .
+```
+
+### Run the image
+
+Once image is built, simply run
+
+```sh
+docker run -d \
+    --name mouthful \
+    -v $(pwd)/data
+    -p 8080:8080
+    mouthful
+```
+
+Alternatively you can use the official image `vkuznecovas/mouthful`
+
+```sh
+docker run -d \
+    --name mouthful \
+    -v $(pwd)/app/data
+    -p 8080:8080
+    vkuznecovas/mouthful
+```
+
+**Note:** `/app/data` needs to contain a valid `config.json` file, read the note in [moderation](#moderation). You can extract the config file from the docker image, see [getting config file from docker](#config-file-from-docker).
 
 # Configuring mouthful
 
@@ -77,34 +138,36 @@ Nearly all the features of mouthful can be customized and turned on or off. All 
 
 Here's a short overview:
 
-### Moderation
+## Moderation
 
 Mouthful comes with moderation support out of the box. If moderation is enabled, it does not show the comments users post instantly, those will have to be approved first through the mouthful admin panel. This also allows for comment modification or deletion.
 
-### Caching
+**Note:** You need to change the default password in [config.json](config.json#L5), else `mouthful` will fail to start.
+
+## Caching
 
 Mouthful can cache end results(full sets of comments for threads) for a given period of time. This allows for quicker responses, lower number of database queries at the cost of extra memory for the running mouthful binary.
 
-### Rate limiting
+## Rate limiting
 
 Mouthful can limit the amount of posts a person can post within the same hour.
 
-### Styling
+## Styling
 
 Mouthful comes with a default style out of the box, but you can override it in a couple of ways:
 
 1) Disable the default styling in config and add the required css to your webpage.
 2) Fork the repo and change the style in `client/src/components/client/style.scss`.
 
-### Paging of comments
+## Paging of comments
 
 Mouthful can either display all the comments on page load, or page them. The page size can be specified in config.
 
-### Cross-Origin Resource Sharing
+## Cross-Origin Resource Sharing
 
 Mouthful can either allow all origins to access its backend from browser or limit that to a given list of domains.
 
-### Data sources
+## Data sources
 
 Mouthful supports different data stores for different needs. Currently supported data store list is as follows:
 
@@ -114,6 +177,16 @@ Mouthful supports different data stores for different needs. Currently supported
 * aws dynamodb
 
 For a list of configuration options and config file examples, head over to [configuration documentation and examples](./examples/configs/README.md)
+
+## Config file from Docker
+
+You can get the default `config.json` by running
+
+```sh
+docker run --rm vkuznecovas/mouthful cat /app/data/config.json > config.json
+```
+
+This will create a file name `config.json` in your host machine, you can edit it as you please. Make sure it is present in the `data` folder before runnig the docker image, read the note in [run the image](#run-the-image).
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There's a demo hosted at [mouthful.dizzy.zone](https://mouthful.dizzy.zone). Che
     * [Caching](#caching)
     * [Rate limiting](#rate-limiting)
     * [Styling](#styling)
-    * [Cross-origin resource sharing](#cross-origin resource sharing)
+    * [Cross-origin resource sharing](#cross-origin-resource-sharing)
     * [Data sources](#data-source)
     * [Config file from Docker image](#config-file-from-docker)
 * [Contributing](#contributing)

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-set +x
+set -euxo
 rm -rf ./dist
 # make dirs to accomodate files
 mkdir -p ./dist
 mkdir -p ./dist/static
+mkdir -p ./dist/data
 
 # bundle client
 cd ./client
@@ -24,8 +25,8 @@ cd ..
 dep ensure
 
 # build binary
-go build -o dist/mouthful main.go
+go build -a -ldflags="-s -w" -installsuffix cgo -o dist/mouthful main.go
 chmod +x dist/mouthful
 
 # copy over config
-cp ./config.json dist/config.json
+cp ./config.json dist/data/config.json

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     },
     "database": {
         "dialect": "sqlite3",
-        "database": "./_mouthful_db/test.db"
+        "database": "./data/test.db"
     },
     "api": {
         "port": 8080,

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	// read config.json
-	contents, err := ioutil.ReadFile("./config.json")
+	contents, err := ioutil.ReadFile("./data/config.json")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Improve docker image
* Dockerfile builds mouthful from source using a multi-stage Dockerfile
    * Builds on master branch
    * Builds a static binary and compress it with upx
    * Version can be specified on build time with `--build-arg MOUTHFUL_VER=[VERSION]`
    * Uses `golang:1.10-alpine` since it is a multi-arch image, that means the project can be cloned and the image can be built on ARM devices for instance.
    * Persist data volume (containing the config file and db). As a side note i think you should remove the default password error, so it can work out of the box.
    * Resulting image based on `FROM alpine:3.7`
    * Resulting image is about `12.8MB`.
* Modify `main.go` to update with the new config file location
* Add image usage to the readme

I didn't know if you have a docker repo for this image, yet i added to the readme that this repo has an official image at `vkuznecovas/mouthful` ready to be pulled, feel free to change with the actual image, if that's not the case.

It'd be nice that you create a new release if these changes get merged.