### PR TITLE
Accept bind address as a parameter

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,6 +12,7 @@
         "database": "./data/test.db"
     },
     "api": {
+        "bindAddress": "0.0.0.0",
         "port": 8080,
         "logging": true,
         "debug": false,

--- a/config/model/config.go
+++ b/config/model/config.go
@@ -42,6 +42,7 @@ type Config struct {
 // API - api configuration part
 type API struct {
 	Port         *int         `json:"port,omitempty"`
+	BindAddress  *string      `json:"bindAddress,omitempty"`
 	Debug        bool         `json:"debug"`
 	Cache        Cache        `json:"cache"`
 	RateLimiting RateLimiting `json:"rateLimiting"`

--- a/global/defaults.go
+++ b/global/defaults.go
@@ -4,6 +4,9 @@ package global
 // StaticPath is the default location for our static files
 const StaticPath = "./static"
 
+// DefaultBindAddress is the default value for api service bind address
+const DefaultBindAddress = "0.0.0.0"
+
 // DefaultPort is the default value for api port
 const DefaultPort = 8080
 

--- a/main.go
+++ b/main.go
@@ -41,12 +41,19 @@ func main() {
 	}
 
 	// set GIN port
-	port := fmt.Sprintf(":%v", global.DefaultPort)
+	port := global.DefaultPort
 	if config.API.Port != nil {
-		port = fmt.Sprintf(":%v", *config.API.Port)
+		port = *config.API.Port
+	}
+
+	// add GIN bind address, serving on all by default
+	bindAddress := global.DefaultBindAddress
+	if config.API.BindAddress != nil {
+		bindAddress = *config.API.BindAddress
 	}
 
 	// run the server
-	log.Println("Running server on port", port)
-	service.Run(port)
+	fullAddress := fmt.Sprintf("%v:%v", bindAddress, port)
+	log.Println("Running server on ", fullAddress)
+	service.Run(fullAddress)
 }


### PR DESCRIPTION
So we can bind it to localhost or specific interface/IP, which I assume a way more secure approach while using a redirection layer like nginx proxy_pass.